### PR TITLE
Split queries to avoid timeout

### DIFF
--- a/.github/workflows/publish_requests.yml
+++ b/.github/workflows/publish_requests.yml
@@ -90,9 +90,6 @@ jobs:
         with:
           query: |
             query {
-              doc: repository(owner: "AliceO2Group", name: "dpg-documentation") {
-                id
-              }
               O2DPG: repository(owner: "AliceO2Group", name: "O2DPG") {
                 pullRequests(first: 100, states: [MERGED, OPEN], orderBy: { field: UPDATED_AT, direction: DESC }) {
                   nodes {
@@ -136,9 +133,6 @@ jobs:
         with:
           query: |
             query {
-              doc: repository(owner: "AliceO2Group", name: "dpg-documentation") {
-                id
-              }
               QualityControl: repository(owner: "AliceO2Group", name: "QualityControl") {
                 pullRequests(first: 100, states: [MERGED, OPEN], orderBy: { field: UPDATED_AT, direction: DESC }) {
                   nodes {
@@ -182,9 +176,6 @@ jobs:
         with:
           query: |
             query {
-              doc: repository(owner: "AliceO2Group", name: "dpg-documentation") {
-                id
-              }
               O2Physics: repository(owner: "AliceO2Group", name: "O2Physics") {
                 pullRequests(first: 100, states: [MERGED, OPEN], orderBy: { field: UPDATED_AT, direction: DESC }) {
                   nodes {

--- a/.github/workflows/publish_requests.yml
+++ b/.github/workflows/publish_requests.yml
@@ -36,8 +36,8 @@ jobs:
           # Overwrite branch, creating a new one based on HEAD
           git checkout -B auto-update-requests
 
-      - name: Get PRs
-        id: get_prs
+      - name: Get PRs from AliceO2
+        id: get_prs_o2
         uses: octokit/graphql-action@v2.x
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -80,6 +80,19 @@ jobs:
                   }
                 }
               }
+            }
+
+      - name: Get PRs from O2DPG
+        id: get_prs_o2dpg
+        uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          query: |
+            query {
+              doc: repository(owner: "AliceO2Group", name: "dpg-documentation") {
+                id
+              }
               O2DPG: repository(owner: "AliceO2Group", name: "O2DPG") {
                 pullRequests(first: 100, states: [MERGED, OPEN], orderBy: { field: UPDATED_AT, direction: DESC }) {
                   nodes {
@@ -113,6 +126,19 @@ jobs:
                   }
                 }
               }
+            }
+
+      - name: Get PRs from QC
+        id: get_prs_qc
+        uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          query: |
+            query {
+              doc: repository(owner: "AliceO2Group", name: "dpg-documentation") {
+                id
+              }
               QualityControl: repository(owner: "AliceO2Group", name: "QualityControl") {
                 pullRequests(first: 100, states: [MERGED, OPEN], orderBy: { field: UPDATED_AT, direction: DESC }) {
                   nodes {
@@ -145,6 +171,19 @@ jobs:
                     }
                   }
                 }
+              }
+            }
+
+      - name: Get PRs from O2Physics
+        id: get_prs_o2physics
+        uses: octokit/graphql-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          query: |
+            query {
+              doc: repository(owner: "AliceO2Group", name: "dpg-documentation") {
+                id
               }
               O2Physics: repository(owner: "AliceO2Group", name: "O2Physics") {
                 pullRequests(first: 100, states: [MERGED, OPEN], orderBy: { field: UPDATED_AT, direction: DESC }) {
@@ -180,6 +219,15 @@ jobs:
                 }
               }
             }
+
+      - name: Combine PRs
+        id: combine_prs
+        run: |
+          echo "${{ steps.get_prs_o2.outputs.data }}" > prs_o2.json
+          echo "${{ steps.get_prs_o2dpg.outputs.data }}" > prs_o2dpg.json
+          echo "${{ steps.get_prs_qc.outputs.data }}" > prs_qc.json
+          echo "${{ steps.get_prs_o2physics.outputs.data }}" > prs_o2physics.json
+          jq -s '.[0] * .[1] * .[2] * .[3]' prs_o2.json prs_o2dpg.json prs_qc.json prs_o2physics.json > prs.json
 
       - name: Store PRs
         run: |


### PR DESCRIPTION
The timeout issue might be caused by the size of the single query to GitHub. Splitting with multiple queries might fix the problem. Outputs are later merged and the workflow continues as usual. 